### PR TITLE
Return groups from credentials/1

### DIFF
--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -134,6 +134,7 @@ defmodule Ueberauth.Strategy.Cognito do
 
   def credentials(conn) do
     token = conn.private.cognito_token
+    id_token = conn.private.cognito_id_token
 
     expires_at =
       if token["expires_in"] do
@@ -144,7 +145,8 @@ defmodule Ueberauth.Strategy.Cognito do
       token: token["access_token"],
       refresh_token: token["refresh_token"],
       expires: !!expires_at,
-      expires_at: expires_at
+      expires_at: expires_at,
+      other: %{groups: id_token["cognito:groups"] || []}
     }
   end
 

--- a/test/ueberauth/strategy/cognito_test.exs
+++ b/test/ueberauth/strategy/cognito_test.exs
@@ -284,12 +284,36 @@ defmodule Ueberauth.Strategy.CognitoTest do
         "access_token" => "access_token",
         "refresh_token" => "refresh_token"
       })
+      |> put_private(:cognito_id_token, %{"cognito:groups" => ["test1"]})
 
     assert %Ueberauth.Auth.Credentials{
              token: "access_token",
              refresh_token: "refresh_token",
              expires: true,
-             expires_at: expires_at
+             expires_at: expires_at,
+             other: %{groups: ["test1"]}
+           } = Cognito.credentials(conn)
+
+    assert expires_at >= System.system_time(:seconds) + 99
+    assert expires_at <= System.system_time(:seconds) + 101
+  end
+
+  test "credentials/1 without any group information" do
+    conn =
+      conn(:get, "/auth/cognito/callback")
+      |> put_private(:cognito_token, %{
+        "expires_in" => 100,
+        "access_token" => "access_token",
+        "refresh_token" => "refresh_token"
+      })
+      |> put_private(:cognito_id_token, %{})
+
+    assert %Ueberauth.Auth.Credentials{
+             token: "access_token",
+             refresh_token: "refresh_token",
+             expires: true,
+             expires_at: expires_at,
+             other: %{groups: []}
            } = Cognito.credentials(conn)
 
     assert expires_at >= System.system_time(:seconds) + 99


### PR DESCRIPTION
These are present in the `cognito:groups` field in the ID token. Also gracefully handle the case where we didn't receive that field in the JSON for whatever reason.

I did some manual testing with `IO.inspect` and it seems to work.