### PR TITLE
Support refresh tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,9 @@ end
 ```
 
 Note that the entry in the `router` defines the authentication callback URL, and will need to be whitelisted in the AWS Cognito User Pools settings.
+
+## Refreshing access tokens
+
+Cognito supports [using refresh tokens](https://www.oauth.com/oauth2-servers/access-tokens/refreshing-access-tokens/) to automatically obtain new access tokens for users whose access tokens expire. If the callback URL is called with the `refresh_token` param set, Ueberauth will attempt to use the given refresh token value to obtain a new, fresh access token.
+
+The refresh token for an access token is issued at the same time as the access token, and is available in the `Ueberauth.Auth.Credentials` struct. Whether to use refresh tokens, and where to store them if used, is an implementation detail. Your first instinct might be to store them in a cookie, but they can sometimes exceed the maximum possible cookie size. An alternative is to store an identifier (which could be a username, or simply a random nonce) in a cookie, and create a GenServer that maps these identifiers to refresh tokens. This has the advantage of not revealing the refresh tokens to the end user, if this is a consideration.

--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -138,7 +138,7 @@ defmodule Ueberauth.Strategy.Cognito do
 
     expires_at =
       if token["expires_in"] do
-        System.system_time(:seconds) + token["expires_in"]
+        System.system_time(:second) + token["expires_in"]
       end
 
     %Ueberauth.Auth.Credentials{

--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -33,7 +33,7 @@ defmodule Ueberauth.Strategy.Cognito do
     config = Config.get_config()
 
     with {:ok, token} <- request_token_refresh(refresh_token, config) do
-      conn = extract_and_verify_token(conn, token, config)
+      extract_and_verify_token(conn, token, config)
     else
       {:error, :cannot_refresh_access_token} ->
         set_errors!(conn, error("aws_response", "Non-200 error code from AWS"))
@@ -85,16 +85,9 @@ defmodule Ueberauth.Strategy.Cognito do
              jwks,
              config
            ) do
-      conn =
-        conn
-        |> put_private(:cognito_token, token)
-        |> put_private(:cognito_id_token, id_token)
-
-      if token["refresh_token"] do
-        put_private(conn, :cognito_refresh_token, token["refresh_token"])
-      else
-        conn
-      end
+      conn
+      |> put_private(:cognito_token, token)
+      |> put_private(:cognito_id_token, id_token)
     else
       {:error, :cannot_fetch_jwks} ->
         set_errors!(conn, error("jwks_response", "Error fetching JWKs"))

--- a/lib/ueberauth/strategy/cognito/jwt_verifier.ex
+++ b/lib/ueberauth/strategy/cognito/jwt_verifier.ex
@@ -11,7 +11,7 @@ defmodule Ueberauth.Strategy.Cognito.JwtVerifier do
     with {:ok, claims_json} <- verified_claims(jwks, jwt),
          {:ok, claims} <- Jason.decode(claims_json),
          true <- claims["aud"] == config.client_id,
-         true <- claims["exp"] > System.system_time(:seconds),
+         true <- claims["exp"] > System.system_time(:second),
          true <- claims["iss"] == Utilities.jwk_url_prefix(config),
          true <- claims["token_use"] in ["id", "access"] do
       {:ok, claims}

--- a/test/ueberauth/strategy/cognito/jwt_verifier_test.exs
+++ b/test/ueberauth/strategy/cognito/jwt_verifier_test.exs
@@ -134,7 +134,7 @@ defmodule Ueberauth.Strategy.Cognito.JwtVerifierTest do
       rsa_public_jwk = JOSE.JWK.to_public(rsa_private_jwk)
 
       jws = valid_jws()
-      jwt = %{valid_jwt() | "exp" => System.system_time(:seconds) - 500}
+      jwt = %{valid_jwt() | "exp" => System.system_time(:second) - 500}
 
       {_algo_meta, signed_jwt} =
         JOSE.JWT.sign(rsa_private_jwk, jws, jwt)
@@ -196,7 +196,7 @@ defmodule Ueberauth.Strategy.Cognito.JwtVerifierTest do
   defp valid_jwt do
     %{
       "iss" => "https://cognito-idp.#{@config.aws_region}.amazonaws.com/#{@config.user_pool_id}",
-      "exp" => System.system_time(:seconds) + 500,
+      "exp" => System.system_time(:second) + 500,
       "aud" => @config.client_id,
       "token_use" => "id"
     }

--- a/test/ueberauth/strategy/cognito_test.exs
+++ b/test/ueberauth/strategy/cognito_test.exs
@@ -294,8 +294,8 @@ defmodule Ueberauth.Strategy.CognitoTest do
              other: %{groups: ["test1"]}
            } = Cognito.credentials(conn)
 
-    assert expires_at >= System.system_time(:seconds) + 99
-    assert expires_at <= System.system_time(:seconds) + 101
+    assert expires_at >= System.system_time(:second) + 99
+    assert expires_at <= System.system_time(:second) + 101
   end
 
   test "credentials/1 without any group information" do
@@ -316,8 +316,8 @@ defmodule Ueberauth.Strategy.CognitoTest do
              other: %{groups: []}
            } = Cognito.credentials(conn)
 
-    assert expires_at >= System.system_time(:seconds) + 99
-    assert expires_at <= System.system_time(:seconds) + 101
+    assert expires_at >= System.system_time(:second) + 99
+    assert expires_at <= System.system_time(:second) + 101
   end
 
   test "info/1" do


### PR DESCRIPTION
This adds a clause to `handle_callback!` that allows use of a refresh token to acquire a new access token without having to log in again. See https://www.oauth.com/oauth2-servers/access-tokens/refreshing-access-tokens/.