### PR TITLE
Return a more specific error when use of refresh token fails

### DIFF
--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -36,7 +36,10 @@ defmodule Ueberauth.Strategy.Cognito do
       extract_and_verify_token(conn, token, config)
     else
       {:error, :cannot_refresh_access_token} ->
-        set_errors!(conn, error("aws_response", "Non-200 error code from AWS"))
+        set_errors!(
+          conn,
+          error("refresh_token_failure", "Non-200 error code from AWS when using refresh token")
+        )
     end
   end
 

--- a/test/ueberauth/strategy/cognito_test.exs
+++ b/test/ueberauth/strategy/cognito_test.exs
@@ -155,7 +155,7 @@ defmodule Ueberauth.Strategy.CognitoTest do
                ueberauth_failure: %Ueberauth.Failure{
                  errors: [
                    %Ueberauth.Failure.Error{
-                     message_key: "aws_response"
+                     message_key: "refresh_token_failure"
                    }
                  ]
                }


### PR DESCRIPTION
So that we can handle this specific case more easily on the Signs UI end.