### PR TITLE
chore: Add codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+codecov:
+  bot: mbtace
+  notify:
+    require_ci_to_pass: true
+comment:
+  behavior: default
+  layout: header, diff
+  require_changes: false
+coverage:
+  precision: 2
+  range:
+  - 70.0
+  - 100.0
+  round: down
+  status:
+    changes: false
+    patch:
+      default:
+        target: 100%
+    project: false
+parsers:
+  gcov:
+    branch_detection:
+      conditional: true
+      loop: true
+      macro: false
+      method: false


### PR DESCRIPTION
Copied from Arrow. It has `bot: mbtace` so I think that might update who the codecov PR posts come from. If not, I think the GitHub webhook has to be updated.