### PR TITLE
Allow getting the config based on the otp_app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+Added per app configuration based on the otp_app
+
 ## 0.1.0
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -72,6 +72,38 @@ end
 
 Note that the entry in the `router` defines the authentication callback URL, and will need to be whitelisted in the AWS Cognito User Pools settings.
 
+## Configuration of settings per OTP app
+
+If you wish to use Ueberauth in multiple OTP apps, and configure each instance of Ueberauth with a different list of Providers and settings, you will need to do some things differently. When providing configuration for Ueberauth, you should set anything that differs by OTP app under the name of your OTP app, for example:
+
+```ex
+config :my_app, Ueberauth,
+  providers: [
+    cognito: {Ueberauth.Strategy.Cognito, []}
+  ]
+```
+
+and configure the required values for the provider (make sure to use the same otp_app name)
+
+```ex
+config :my_app, Ueberauth.Strategy.Cognito,
+  auth_domain: {System, :get_env, ["COGNITO_DOMAIN"]},
+  client_id: {System, :get_env, ["COGNITO_CLIENT_ID"]},
+  client_secret: {System, :get_env, ["COGNITO_CLIENT_SECRET"]},
+  user_pool_id: {System, :get_env, ["COGNITO_USER_POOL_ID"]},
+  aws_region: {System, :get_env, ["COGNITO_AWS_REGION"]} # e.g. "us-east-1"
+```
+
+In your controller, when using the Ueberauth plug, you should pass the `:otp_app` option, for example:
+
+```ex
+defmodule SignsUiWeb.AuthController do
+  use SignsUiWeb, :controller
+  plug(Ueberauth, otp_app: :my_app)
+
+  ...
+```
+
 ## Refreshing access tokens
 
 Cognito supports [using refresh tokens](https://www.oauth.com/oauth2-servers/access-tokens/refreshing-access-tokens/) to automatically obtain new access tokens for users whose access tokens expire. If your application has a refresh token handy, you can redirect to the callback URL with the `refresh_token` param set, and Ueberauth will attempt to use the given refresh token value to obtain a fresh access token.

--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -34,7 +34,7 @@ defmodule Ueberauth.Strategy.Cognito do
     %{
       auth_domain: auth_domain,
       client_id: client_id
-    } = Config.get_config(option(conn, :otp_app))
+    } = Config.get_config(otp_app(conn))
 
     params = %{
       response_type: "code",
@@ -61,7 +61,7 @@ defmodule Ueberauth.Strategy.Cognito do
   given refresh token rather than the normal Cognito flow.
   """
   def handle_callback!(%Plug.Conn{params: %{"refresh_token" => refresh_token}} = conn) do
-    config = Config.get_config(option(conn, :otp_app))
+    config = Config.get_config(otp_app(conn))
 
     with {:ok, token} <- request_token_refresh(refresh_token, config) do
       extract_and_verify_token(conn, token, config)
@@ -97,7 +97,7 @@ defmodule Ueberauth.Strategy.Cognito do
   end
 
   defp exchange_code_for_token(%Plug.Conn{params: %{"code" => code}} = conn) do
-    config = Config.get_config(option(conn, :otp_app))
+    config = Config.get_config(otp_app(conn))
 
     with {:ok, token} <- request_token(conn, code, config) do
       extract_and_verify_token(conn, token, config)
@@ -257,10 +257,12 @@ defmodule Ueberauth.Strategy.Cognito do
     |> put_private(:cognito_id_token, nil)
   end
 
-  defp option(conn, key) do
-    case options(conn) do
-      nil -> Keyword.get(default_options(), key)
-      opts -> Keyword.get(opts, key, Keyword.get(default_options(), key))
+  defp otp_app(conn) do
+    default_app = :ueberauth
+    if opts = options(conn) do
+      Keyword.get(opts, :otp_app, default_app)
+    else
+      default_app
     end
   end
 end

--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -34,7 +34,7 @@ defmodule Ueberauth.Strategy.Cognito do
     %{
       auth_domain: auth_domain,
       client_id: client_id
-    } = Config.get_config()
+    } = Config.get_config(option(conn, :otp_app))
 
     params = %{
       response_type: "code",
@@ -61,7 +61,7 @@ defmodule Ueberauth.Strategy.Cognito do
   given refresh token rather than the normal Cognito flow.
   """
   def handle_callback!(%Plug.Conn{params: %{"refresh_token" => refresh_token}} = conn) do
-    config = Config.get_config()
+    config = Config.get_config(option(conn, :otp_app))
 
     with {:ok, token} <- request_token_refresh(refresh_token, config) do
       extract_and_verify_token(conn, token, config)
@@ -97,7 +97,7 @@ defmodule Ueberauth.Strategy.Cognito do
   end
 
   defp exchange_code_for_token(%Plug.Conn{params: %{"code" => code}} = conn) do
-    config = Config.get_config()
+    config = Config.get_config(option(conn, :otp_app))
 
     with {:ok, token} <- request_token(conn, code, config) do
       extract_and_verify_token(conn, token, config)
@@ -255,5 +255,12 @@ defmodule Ueberauth.Strategy.Cognito do
     conn
     |> put_private(:cognito_token, nil)
     |> put_private(:cognito_id_token, nil)
+  end
+
+  defp option(conn, key) do
+    case options(conn) do
+      nil -> Keyword.get(default_options(), key)
+      opts -> Keyword.get(opts, key, Keyword.get(default_options(), key))
+    end
   end
 end

--- a/lib/ueberauth/strategy/cognito/config.ex
+++ b/lib/ueberauth/strategy/cognito/config.ex
@@ -19,8 +19,8 @@ defmodule Ueberauth.Strategy.Cognito.Config do
   defstruct @enforce_keys
 
   @doc false
-  def get_config do
-    config = Application.get_env(:ueberauth, Ueberauth.Strategy.Cognito) || %{}
+  def get_config(otp_app) do
+    config = Application.get_env(otp_app || :ueberauth, Ueberauth.Strategy.Cognito) || %{}
 
     strategy_config =
       Map.new(@strategy_keys, fn c ->

--- a/test/ueberauth/strategy/cognito_test.exs
+++ b/test/ueberauth/strategy/cognito_test.exs
@@ -433,4 +433,32 @@ defmodule Ueberauth.Strategy.CognitoTest do
     assert conn.private.cognito_id_token == nil
     assert conn.private.cognito_token == nil
   end
+
+  test "different configurations can be used by setting otp_app" do
+    # set an environment with a custom app name
+    Application.put_env(:custom_app, Ueberauth.Strategy.Cognito, %{
+      auth_domain: "customdomain.com",
+      client_id: "custom_client_id",
+      client_secret: {Ueberauth.Strategy.CognitoTest.Identity, :id, ["custom_client_secret"]},
+      user_pool_id: "custom_user_pool_id",
+      aws_region: "us-east-2"
+    })
+
+    conn =
+      conn(:get, "/auth/cognito")
+      |> put_private(:ueberauth_request_options, options: [otp_app: :custom_app])
+      |> init_test_session(%{})
+      |> Cognito.handle_request!()
+
+    assert conn.status == 302
+
+    {"location", redirect_location} =
+      Enum.find(conn.resp_headers, fn {header, _} -> header == "location" end)
+
+    assert String.starts_with?(redirect_location, "https://customdomain.com/oauth2/authorize")
+    assert redirect_location =~ "client_id=custom_client_id"
+
+    # clean up
+    Application.delete_env(:custom_app, Ueberauth.Strategy.Cognito)
+  end
 end


### PR DESCRIPTION
In ueberauth 0.6, support was added to allow multiple configurations of a strategy based on the `otp_app`. This simple patch adds in support for this, allowing different elixir apps to have separate cognito configurations.

This change is backward compatible, and if the `otp_app` is not set, it fails back to the default `:ueberauth` app.