### PR TITLE
Support optional params & implement info/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-Added per app configuration based on the otp_app
+* Added per app configuration based on the otp_app
+* Support some optional parameters for Cognito `/authorize`
+* Modified to return `info/1` with the information of User in `Ueberauth.Auth.Info`
 
 ## 0.1.0
 

--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -246,10 +246,22 @@ defmodule Ueberauth.Strategy.Cognito do
   end
 
   @doc """
-  Currently doesn't return any additional information.
+  Fetches the fields to populate the info section of the `Ueberauth.Auth` struct.
   """
-  def info(_conn) do
-    %Ueberauth.Auth.Info{}
+  def info(conn) do
+    id_token = conn.private[:cognito_id_token]
+    %Ueberauth.Auth.Info{
+      email:       id_token["email"],
+      name:        id_token["cognito:username"],
+      first_name:  id_token["given_name"],
+      last_name:   id_token["family_name"],
+      nickname:    id_token["nickname"],
+      location:    id_token["address"],
+      description: id_token["description"],
+      image:       id_token["picture"],
+      phone:       id_token["phone_number"],
+      birthday:    id_token["birthdate"],
+    }
   end
 
   @doc """

--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -22,7 +22,8 @@ defmodule Ueberauth.Strategy.Cognito do
   """
 
   use Ueberauth.Strategy,
-    uid_field: "cognito:username"
+    uid_field: "cognito:username",
+    name_field: "name"
 
   alias Ueberauth.Strategy.Cognito.Utilities
   alias Ueberauth.Strategy.Cognito.Config
@@ -254,7 +255,7 @@ defmodule Ueberauth.Strategy.Cognito do
     id_token = conn.private[:cognito_id_token]
     %Ueberauth.Auth.Info{
       email:       id_token["email"],
-      name:        id_token["cognito:username"],
+      name:        id_token[option(conn, :name_field)],
       first_name:  id_token["given_name"],
       last_name:   id_token["family_name"],
       nickname:    id_token["nickname"],

--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -21,7 +21,9 @@ defmodule Ueberauth.Strategy.Cognito do
   shouldn't have to concern themselves with them.
   """
 
-  use Ueberauth.Strategy
+  use Ueberauth.Strategy,
+    uid_field: "cognito:username"
+
   alias Ueberauth.Strategy.Cognito.Utilities
   alias Ueberauth.Strategy.Cognito.Config
 
@@ -242,7 +244,7 @@ defmodule Ueberauth.Strategy.Cognito do
   Returns the username given in the Cognito response.
   """
   def uid(conn) do
-    conn.private.cognito_id_token["cognito:username"]
+    conn.private.cognito_id_token[option(conn, :uid_field)]
   end
 
   @doc """
@@ -290,5 +292,9 @@ defmodule Ueberauth.Strategy.Cognito do
     else
       default_app
     end
+  end
+
+  defp option(conn, key) do
+    Map.get(Config.get_config(otp_app(conn)),key) || Keyword.get(default_options(), key)
   end
 end

--- a/lib/ueberauth/strategy/cognito/config.ex
+++ b/lib/ueberauth/strategy/cognito/config.ex
@@ -14,9 +14,14 @@ defmodule Ueberauth.Strategy.Cognito.Config do
     :jwt_verifier
   ]
 
+  @optional_keys [
+    :uid_field,
+    :name_field
+  ]
+
   @enforce_keys @strategy_keys ++ @dependency_keys
 
-  defstruct @enforce_keys
+  defstruct @enforce_keys ++ @optional_keys
 
   @doc false
   def get_config(otp_app) do
@@ -37,7 +42,14 @@ defmodule Ueberauth.Strategy.Cognito.Config do
         )
     }
 
-    overall_config = Map.merge(strategy_config, dependency_config)
+    optional_config =
+      Map.new(@optional_keys, fn c ->
+        {c, config_value(config[c])}
+      end)
+
+    overall_config = optional_config
+    |> Map.merge(strategy_config)
+    |> Map.merge(dependency_config)
 
     struct(
       __MODULE__,
@@ -45,6 +57,6 @@ defmodule Ueberauth.Strategy.Cognito.Config do
     )
   end
 
-  defp config_value(value) when is_binary(value), do: value
+  defp config_value(value) when is_binary(value) or is_nil(value), do: value
   defp config_value({m, f, a}), do: apply(m, f, a)
 end

--- a/test/ueberauth/strategy/cognito/jwt_verifier_test.exs
+++ b/test/ueberauth/strategy/cognito/jwt_verifier_test.exs
@@ -68,7 +68,7 @@ defmodule Ueberauth.Strategy.Cognito.JwtVerifierTest do
     user_pool_id: "user_pool_id",
     aws_region: "aws_region",
     http_client: :hackney,
-    jwt_verifier: Ueberauth.Strategy.Cognito.JwtVerifier
+    jwt_verifier: Ueberauth.Strategy.Cognito.JwtVerifier,
   }
 
   describe "verify/3" do

--- a/test/ueberauth/strategy/cognito_test.exs
+++ b/test/ueberauth/strategy/cognito_test.exs
@@ -14,7 +14,39 @@ defmodule Ueberauth.Strategy.CognitoTest do
 
     def body(:successful_post_ref) do
       id_token_payload =
-        %{"email" => "foo"}
+        %{
+          "email" => "foo",
+          "email_verified" => false,
+          "at_hash" => "hash",
+          "aud" => "3rgcfma9qb6ol300sbo3e37a29",
+          "auth_time" => 1589385933,
+          "cognito:groups" => ["ap-northeast-1_xxxx"],
+          "cognito:username" => "UserName",
+          "exp" => 1589389533,
+          "iat" => 1589385933,
+          "identities" => [
+            %{
+              "dateCreated" => "1589384379675",
+              "issuer" => "urn:xxxx.com",
+              "primary" => "true",
+              "providerName" => "idp-name",
+              "providerType" => "SAML",
+              "userId" => "user-id"
+            }
+          ],
+          "iss" => "https://cognito-idp.ap-northeast-1.amazonaws.com/ap-northeast-1_xxxx",
+          "name" => "UserName",
+          "sub" => "xxxx",
+          "token_use" => "id",
+          "nickname" => "Nickname",
+          "given_name" => "Given",
+          "family_name" => "Family",
+          "family_name" => "Family",
+          "address" => "Japan",
+          "picture" => "https://example.com/img",
+          "phone_number" => "1234567890",
+          "birthdate" => "2020-05-15",
+        }
         |> Jason.encode!()
         |> Base.url_encode64(padding: false)
 
@@ -156,11 +188,10 @@ defmodule Ueberauth.Strategy.CognitoTest do
         |> Plug.Conn.fetch_query_params()
         |> Cognito.handle_callback!()
 
-      assert conn.private.cognito_id_token == %{"email" => "foo"}
-
+      assert %{"email" => "foo"} = conn.private.cognito_id_token
       assert conn.private.cognito_token == %{
                "access_token" => "the_access_token",
-               "id_token" => "header.eyJlbWFpbCI6ImZvbyJ9.signature",
+               "id_token" => "header.eyJhZGRyZXNzIjoiSmFwYW4iLCJhdF9oYXNoIjoiaGFzaCIsImF1ZCI6IjNyZ2NmbWE5cWI2b2wzMDBzYm8zZTM3YTI5IiwiYXV0aF90aW1lIjoxNTg5Mzg1OTMzLCJiaXJ0aGRhdGUiOiIyMDIwLTA1LTE1IiwiY29nbml0bzpncm91cHMiOlsiYXAtbm9ydGhlYXN0LTFfeHh4eCJdLCJjb2duaXRvOnVzZXJuYW1lIjoiVXNlck5hbWUiLCJlbWFpbCI6ImZvbyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiZXhwIjoxNTg5Mzg5NTMzLCJmYW1pbHlfbmFtZSI6IkZhbWlseSIsImdpdmVuX25hbWUiOiJHaXZlbiIsImlhdCI6MTU4OTM4NTkzMywiaWRlbnRpdGllcyI6W3siZGF0ZUNyZWF0ZWQiOiIxNTg5Mzg0Mzc5Njc1IiwiaXNzdWVyIjoidXJuOnh4eHguY29tIiwicHJpbWFyeSI6InRydWUiLCJwcm92aWRlck5hbWUiOiJpZHAtbmFtZSIsInByb3ZpZGVyVHlwZSI6IlNBTUwiLCJ1c2VySWQiOiJ1c2VyLWlkIn1dLCJpc3MiOiJodHRwczovL2NvZ25pdG8taWRwLmFwLW5vcnRoZWFzdC0xLmFtYXpvbmF3cy5jb20vYXAtbm9ydGhlYXN0LTFfeHh4eCIsIm5hbWUiOiJVc2VyTmFtZSIsIm5pY2tuYW1lIjoiTmlja25hbWUiLCJwaG9uZV9udW1iZXIiOiIxMjM0NTY3ODkwIiwicGljdHVyZSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vaW1nIiwic3ViIjoieHh4eCIsInRva2VuX3VzZSI6ImlkIn0.signature",
                "refresh_token" => "a_refresh_token"
              }
     end
@@ -242,11 +273,10 @@ defmodule Ueberauth.Strategy.CognitoTest do
         |> Plug.Conn.fetch_query_params()
         |> Cognito.handle_callback!()
 
-      assert conn.private.cognito_id_token == %{"email" => "foo"}
-
+      assert %{"email" => "foo"} = conn.private.cognito_id_token
       assert conn.private.cognito_token == %{
                "access_token" => "the_access_token",
-               "id_token" => "header.eyJlbWFpbCI6ImZvbyJ9.signature",
+               "id_token" => "header.eyJhZGRyZXNzIjoiSmFwYW4iLCJhdF9oYXNoIjoiaGFzaCIsImF1ZCI6IjNyZ2NmbWE5cWI2b2wzMDBzYm8zZTM3YTI5IiwiYXV0aF90aW1lIjoxNTg5Mzg1OTMzLCJiaXJ0aGRhdGUiOiIyMDIwLTA1LTE1IiwiY29nbml0bzpncm91cHMiOlsiYXAtbm9ydGhlYXN0LTFfeHh4eCJdLCJjb2duaXRvOnVzZXJuYW1lIjoiVXNlck5hbWUiLCJlbWFpbCI6ImZvbyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiZXhwIjoxNTg5Mzg5NTMzLCJmYW1pbHlfbmFtZSI6IkZhbWlseSIsImdpdmVuX25hbWUiOiJHaXZlbiIsImlhdCI6MTU4OTM4NTkzMywiaWRlbnRpdGllcyI6W3siZGF0ZUNyZWF0ZWQiOiIxNTg5Mzg0Mzc5Njc1IiwiaXNzdWVyIjoidXJuOnh4eHguY29tIiwicHJpbWFyeSI6InRydWUiLCJwcm92aWRlck5hbWUiOiJpZHAtbmFtZSIsInByb3ZpZGVyVHlwZSI6IlNBTUwiLCJ1c2VySWQiOiJ1c2VyLWlkIn1dLCJpc3MiOiJodHRwczovL2NvZ25pdG8taWRwLmFwLW5vcnRoZWFzdC0xLmFtYXpvbmF3cy5jb20vYXAtbm9ydGhlYXN0LTFfeHh4eCIsIm5hbWUiOiJVc2VyTmFtZSIsIm5pY2tuYW1lIjoiTmlja25hbWUiLCJwaG9uZV9udW1iZXIiOiIxMjM0NTY3ODkwIiwicGljdHVyZSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vaW1nIiwic3ViIjoieHh4eCIsInRva2VuX3VzZSI6ImlkIn0.signature",
                "refresh_token" => "a_refresh_token"
              }
     end
@@ -431,10 +461,42 @@ defmodule Ueberauth.Strategy.CognitoTest do
     assert expires_at <= System.system_time(:second) + 101
   end
 
-  test "info/1" do
-    conn = conn(:get, "/auth/cognito/callback")
+  describe "info/1" do
+    test "with refresh_token" do
+      Application.put_env(:ueberauth_cognito, :__http_client, FakeHackneySuccess)
 
-    assert %Ueberauth.Auth.Info{} == Cognito.info(conn)
+      conn = conn(:get, "/auth/cognito/callback?refresh_token=abc")
+      |> init_test_session(%{})
+      |> fetch_session()
+      |> Plug.Conn.fetch_query_params()
+      |> Cognito.handle_callback!()
+
+      assert %Ueberauth.Auth.Info{
+          email: "foo",
+          name: "UserName",
+          first_name: "Given",
+          last_name: "Family",
+          nickname: "Nickname",
+          location: "Japan",
+          description: nil,
+          image: "https://example.com/img",
+          phone: "1234567890",
+          birthday: "2020-05-15",
+          urls: %{},
+      } == Cognito.info(conn)
+    end
+
+    test "without refresh_token" do
+      Application.put_env(:ueberauth_cognito, :__http_client, FakeHackneySuccess)
+
+      conn = conn(:get, "/auth/cognito/callback")
+      |> init_test_session(%{})
+      |> fetch_session()
+      |> Plug.Conn.fetch_query_params()
+      |> Cognito.handle_callback!()
+
+      assert %Ueberauth.Auth.Info{} == Cognito.info(conn)
+    end
   end
 
   test "extra/1" do


### PR DESCRIPTION
I have made two modifications.

1. Optional parameters are now supported.
    - https://docs.aws.amazon.com/ja_jp/cognito/latest/developerguide/authorization-endpoint.html
	    - `identity_provider`
    	- `idp_identifier`.
2. Changed to return the information of User from `info/1`.
    - I referred to the following
        - https://github.com/ueberauth/ueberauth_facebook/blob/a351a25fa6/lib/ueberauth/strategy/facebook.ex#L105-L124
        - https://github.com/ueberauth/ueberauth_google/blob/af3138ee63/lib/ueberauth/strategy/google.ex#L94-L112
