### PR TITLE
added support for optional client_secret

### DIFF
--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -201,7 +201,6 @@ defmodule Ueberauth.Strategy.Cognito do
   end
 
   defp post_to_token_endpoint(params, config) do
-  defp post_to_token_endpoint(params, config) do
     headers = [
       {"content-type", "application/x-www-form-urlencoded"}
     ]

--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -181,9 +181,16 @@ defmodule Ueberauth.Strategy.Cognito do
     params = %{
       grant_type: "refresh_token",
       refresh_token: refresh_token,
-      client_id: config.client_id,
-      client_secret: config.client_secret
+      client_id: config.client_id
     }
+
+    # client_secret must be set only if set
+    params =
+      case is_binary(config.client_secret) &&
+             String.length(String.trim(config.client_secret)) > 0 do
+        true -> Map.put(params, :client_secret, config.client_secret)
+        false -> params
+      end
 
     response = post_to_token_endpoint(params, config)
 
@@ -194,15 +201,26 @@ defmodule Ueberauth.Strategy.Cognito do
   end
 
   defp post_to_token_endpoint(params, config) do
-    auth = Base.encode64("#{config.client_id}:#{config.client_secret}")
+  defp post_to_token_endpoint(params, config) do
+    headers = [
+      {"content-type", "application/x-www-form-urlencoded"}
+    ]
+
+    # auth header must be added only if client_secret is set
+    headers =
+      case is_binary(config.client_secret) do
+        true ->
+          auth = Base.encode64("#{config.client_id}:#{config.client_secret}")
+          headers ++ [{"authorization", "Basic #{auth}"}]
+
+        false ->
+          headers
+      end
 
     config.http_client.request(
       :post,
       "https://#{config.auth_domain}/oauth2/token",
-      [
-        {"content-type", "application/x-www-form-urlencoded"},
-        {"authorization", "Basic #{auth}"}
-      ],
+      headers,
       URI.encode_query(params)
     )
   end

--- a/test/ueberauth/strategy/cognito_test.exs
+++ b/test/ueberauth/strategy/cognito_test.exs
@@ -174,33 +174,6 @@ defmodule Ueberauth.Strategy.CognitoTest do
       assert url.query =~ "identity_provider=idp"
       assert url.query =~ "idp_identifier=idp-id"
     end
-
-    test "redirect without client_secret" do
-      # set an environment with a custom app name
-      Application.put_env(:no_client_secret, Ueberauth.Strategy.Cognito, %{
-        auth_domain: "testdomain.com",
-        client_id: "the_client_id",
-        user_pool_id: "the_user_pool_id",
-        aws_region: "us-east-1"
-      })
-
-      conn =
-        conn(:get, "/auth/cognito")
-        |> put_private(:ueberauth_request_options, options: [otp_app: :no_client_secret])
-        |> init_test_session(%{})
-        |> Cognito.handle_request!()
-
-      assert conn.status == 302
-
-      {"location", redirect_location} =
-        Enum.find(conn.resp_headers, fn {header, _} -> header == "location" end)
-
-      assert String.starts_with?(redirect_location, "https://testdomain.com/oauth2/authorize")
-      assert redirect_location =~ "client_id=the_client_id"
-
-      # clean up
-      Application.delete_env(:no_client_secret, Ueberauth.Strategy.Cognito)
-    end
   end
 
   describe "handle_callback! with refresh token" do
@@ -220,6 +193,37 @@ defmodule Ueberauth.Strategy.CognitoTest do
                "id_token" => "header.eyJhZGRyZXNzIjoiSmFwYW4iLCJhdF9oYXNoIjoiaGFzaCIsImF1ZCI6IjNyZ2NmbWE5cWI2b2wzMDBzYm8zZTM3YTI5IiwiYXV0aF90aW1lIjoxNTg5Mzg1OTMzLCJiaXJ0aGRhdGUiOiIyMDIwLTA1LTE1IiwiY29nbml0bzpncm91cHMiOlsiYXAtbm9ydGhlYXN0LTFfeHh4eCJdLCJjb2duaXRvOnVzZXJuYW1lIjoiVXNlck5hbWUiLCJlbWFpbCI6ImZvbyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiZXhwIjoxNTg5Mzg5NTMzLCJmYW1pbHlfbmFtZSI6IkZhbWlseSIsImdpdmVuX25hbWUiOiJHaXZlbiIsImlhdCI6MTU4OTM4NTkzMywiaWRlbnRpdGllcyI6W3siZGF0ZUNyZWF0ZWQiOiIxNTg5Mzg0Mzc5Njc1IiwiaXNzdWVyIjoidXJuOnh4eHguY29tIiwicHJpbWFyeSI6InRydWUiLCJwcm92aWRlck5hbWUiOiJpZHAtbmFtZSIsInByb3ZpZGVyVHlwZSI6IlNBTUwiLCJ1c2VySWQiOiJ1c2VyLWlkIn1dLCJpc3MiOiJodHRwczovL2NvZ25pdG8taWRwLmFwLW5vcnRoZWFzdC0xLmFtYXpvbmF3cy5jb20vYXAtbm9ydGhlYXN0LTFfeHh4eCIsIm5hbWUiOiJVc2VyTmFtZSIsIm5pY2tuYW1lIjoiTmlja25hbWUiLCJwaG9uZV9udW1iZXIiOiIxMjM0NTY3ODkwIiwicGljdHVyZSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vaW1nIiwic3ViIjoieHh4eCIsInRva2VuX3VzZSI6ImlkIn0.signature",
                "refresh_token" => "a_refresh_token"
              }
+    end
+
+    test "puts token information in conn if successful response from AWS without client_secret" do
+      Application.put_env(:no_client_secret, :__http_client, FakeHackneySuccess)
+
+      # set an environment with a custom app name
+      Application.put_env(:no_client_secret, Ueberauth.Strategy.Cognito, %{
+        auth_domain: "testdomain.com",
+        client_id: "the_client_id",
+        user_pool_id: "the_user_pool_id",
+        aws_region: "us-east-1"
+        })
+
+      conn =
+        conn(:get, "/auth/cognito/callback?refresh_token=abc")
+        |> put_private(:ueberauth_request_options, options: [otp_app: :no_client_secret])
+        |> init_test_session(%{})
+        |> fetch_session()
+        |> Plug.Conn.fetch_query_params()
+        |> Cognito.handle_callback!()
+
+      # clean up
+      Application.delete_env(:no_client_secret, Ueberauth.Strategy.Cognito)
+
+      assert %{"email" => "foo"} = conn.private.cognito_id_token
+      assert conn.private.cognito_token == %{
+               "access_token" => "the_access_token",
+               "id_token" => "header.eyJhZGRyZXNzIjoiSmFwYW4iLCJhdF9oYXNoIjoiaGFzaCIsImF1ZCI6IjNyZ2NmbWE5cWI2b2wzMDBzYm8zZTM3YTI5IiwiYXV0aF90aW1lIjoxNTg5Mzg1OTMzLCJiaXJ0aGRhdGUiOiIyMDIwLTA1LTE1IiwiY29nbml0bzpncm91cHMiOlsiYXAtbm9ydGhlYXN0LTFfeHh4eCJdLCJjb2duaXRvOnVzZXJuYW1lIjoiVXNlck5hbWUiLCJlbWFpbCI6ImZvbyIsImVtYWlsX3ZlcmlmaWVkIjpmYWxzZSwiZXhwIjoxNTg5Mzg5NTMzLCJmYW1pbHlfbmFtZSI6IkZhbWlseSIsImdpdmVuX25hbWUiOiJHaXZlbiIsImlhdCI6MTU4OTM4NTkzMywiaWRlbnRpdGllcyI6W3siZGF0ZUNyZWF0ZWQiOiIxNTg5Mzg0Mzc5Njc1IiwiaXNzdWVyIjoidXJuOnh4eHguY29tIiwicHJpbWFyeSI6InRydWUiLCJwcm92aWRlck5hbWUiOiJpZHAtbmFtZSIsInByb3ZpZGVyVHlwZSI6IlNBTUwiLCJ1c2VySWQiOiJ1c2VyLWlkIn1dLCJpc3MiOiJodHRwczovL2NvZ25pdG8taWRwLmFwLW5vcnRoZWFzdC0xLmFtYXpvbmF3cy5jb20vYXAtbm9ydGhlYXN0LTFfeHh4eCIsIm5hbWUiOiJVc2VyTmFtZSIsIm5pY2tuYW1lIjoiTmlja25hbWUiLCJwaG9uZV9udW1iZXIiOiIxMjM0NTY3ODkwIiwicGljdHVyZSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vaW1nIiwic3ViIjoieHh4eCIsInRva2VuX3VzZSI6ImlkIn0.signature",
+               "refresh_token" => "a_refresh_token"
+             }
+
     end
 
     test "returns error if AWS responds with a non-200 for JWT" do


### PR DESCRIPTION
When `client_secret` is not set or empty, it must be omitted from the params and the headers (as for https://stackoverflow.com/a/62800854)

Great work BTW! 👍 