### PR TITLE
Scope can be configured

### DIFF
--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -36,7 +36,8 @@ defmodule Ueberauth.Strategy.Cognito do
   def handle_request!(conn) do
     %{
       auth_domain: auth_domain,
-      client_id: client_id
+      client_id: client_id,
+      scope: scope
     } = Config.get_config(otp_app(conn))
 
     optional_params =
@@ -54,8 +55,7 @@ defmodule Ueberauth.Strategy.Cognito do
         response_type: "code",
         client_id: client_id,
         redirect_uri: callback_url(conn),
-        # TODO - make dynamic (accepting PRs!):
-        scope: "openid profile email"
+        scope: scope
       )
       |> with_state_param(conn)
 

--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -55,7 +55,7 @@ defmodule Ueberauth.Strategy.Cognito do
         response_type: "code",
         client_id: client_id,
         redirect_uri: callback_url(conn),
-        scope: scope
+        scope: scope || "openid profile email"
       )
       |> with_state_param(conn)
 

--- a/lib/ueberauth/strategy/cognito/config.ex
+++ b/lib/ueberauth/strategy/cognito/config.ex
@@ -14,6 +14,10 @@ defmodule Ueberauth.Strategy.Cognito.Config do
     :jwt_verifier
   ]
 
+  @scope_keys [
+    :scope
+  ]
+
   @optional_keys [
     :uid_field,
     :name_field
@@ -21,7 +25,7 @@ defmodule Ueberauth.Strategy.Cognito.Config do
 
   @enforce_keys @strategy_keys ++ @dependency_keys
 
-  defstruct @enforce_keys ++ @optional_keys
+  defstruct @enforce_keys ++ @optional_keys ++ @scope_keys
 
   @doc false
   def get_config(otp_app) do
@@ -42,6 +46,11 @@ defmodule Ueberauth.Strategy.Cognito.Config do
         )
     }
 
+    scope_config =
+      Map.new(@scope_keys, fn c ->
+        {c, config_value(config[c]) || "openid profile email"}
+      end)
+
     optional_config =
       Map.new(@optional_keys, fn c ->
         {c, config_value(config[c])}
@@ -51,6 +60,7 @@ defmodule Ueberauth.Strategy.Cognito.Config do
       optional_config
       |> Map.merge(strategy_config)
       |> Map.merge(dependency_config)
+      |> Map.merge(scope_config)
 
     struct(
       __MODULE__,

--- a/lib/ueberauth/strategy/cognito/config.ex
+++ b/lib/ueberauth/strategy/cognito/config.ex
@@ -14,18 +14,15 @@ defmodule Ueberauth.Strategy.Cognito.Config do
     :jwt_verifier
   ]
 
-  @scope_keys [
-    :scope
-  ]
-
   @optional_keys [
     :uid_field,
-    :name_field
+    :name_field,
+    :scope
   ]
 
   @enforce_keys @strategy_keys ++ @dependency_keys
 
-  defstruct @enforce_keys ++ @optional_keys ++ @scope_keys
+  defstruct @enforce_keys ++ @optional_keys
 
   @doc false
   def get_config(otp_app) do
@@ -46,11 +43,6 @@ defmodule Ueberauth.Strategy.Cognito.Config do
         )
     }
 
-    scope_config =
-      Map.new(@scope_keys, fn c ->
-        {c, config_value(config[c]) || "openid profile email"}
-      end)
-
     optional_config =
       Map.new(@optional_keys, fn c ->
         {c, config_value(config[c])}
@@ -60,7 +52,6 @@ defmodule Ueberauth.Strategy.Cognito.Config do
       optional_config
       |> Map.merge(strategy_config)
       |> Map.merge(dependency_config)
-      |> Map.merge(scope_config)
 
     struct(
       __MODULE__,


### PR DESCRIPTION
- Scope can now be set in Ueberauth.Strategy.Cognito.Config struct
- By default "openid profile email" is used

Configuration example:
```elixir
config :ueberauth, Ueberauth.Strategy.Cognito,
  scope: "openid profile email custom_scope another_custom_scope"
```