### PR TITLE
feat: release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## v0.3.1 (2022-01-14)
+
+- Add support for configuring scopes to include.
+
 ## v0.3.0 (2021-09-01)
 
-* BREAKING: minimum ueberauth version is now 0.7
-* Standardize handling of CSRF Attack protection
+- BREAKING: minimum ueberauth version is now 0.7
+- Standardize handling of CSRF Attack protection
 
 ## v0.2.0 (2020-05-28)
 
-* BREAKING: minimum Elixir version is now 1.7
-* Added per app configuration based on the otp_app
-* Support some optional parameters for Cognito `/authorize`
-* Modified to return `info/1` with the information of User in `Ueberauth.Auth.Info`
+- BREAKING: minimum Elixir version is now 1.7
+- Added per app configuration based on the otp_app
+- Support some optional parameters for Cognito `/authorize`
+- Modified to return `info/1` with the information of User in `Ueberauth.Auth.Info`
 
 Thank you to @mdillavou and @yagince for their contributions to this release!
 
 ## v0.1.0 (2019-12-19)
 
-* Initial release
+- Initial release

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule UeberauthCognito.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/mbta/ueberauth_cognito"
-  @version "0.3.0"
+  @version "0.3.1"
 
   def project do
     [


### PR DESCRIPTION
New release which includes the configuration support for `scope`.

My editor auto-formatted upon save and changed the changelog `*` to `-`. I'm not sure why, but I assume this is preferred for some reason. /shrug.