### PR TITLE
feat: pass along upstream error if provided

### DIFF
--- a/lib/ueberauth/strategy/cognito.ex
+++ b/lib/ueberauth/strategy/cognito.ex
@@ -85,6 +85,12 @@ defmodule Ueberauth.Strategy.Cognito do
     end
   end
 
+  defp exchange_code_for_token(
+         %Plug.Conn{params: %{"error" => _, "error_description" => error_description}} = conn
+       ) do
+    set_errors!(conn, error("upstream_error", error_description))
+  end
+
   defp exchange_code_for_token(conn) do
     set_errors!(conn, error("no_code", "Missing code param"))
   end


### PR DESCRIPTION
Currently, if Cognito provides an error message via the callback, it is silently discarded, and all the application gets is `no_code`. This is not ideal.

I think `upstream_error` is a good value for `message_key`, since the error we saw didn't originate with Cognito but with an upstream service. I can't find the relevant portion of the Cognito docs to confirm whether or not that's reliably the case.

Ordinarily, I'd be opposed to the trailing space in the test case, but since those URL parameters are exactly what we saw in this scenario, I'd rather keep it.